### PR TITLE
ci: only run release ci action in project repo (Resolves #11)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   release-please:
+    if: github.repository == 'inclusive-design/eds.inclusivedesign.ca'
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Sets a condition to only run the release CI task in the projects own repo

## Steps to test

1. Commit this to the main branch of your repo
2. Commit some other changes to the main 
3. Ensure that a release PR isn't generated
4. Reset the changes in your main back to match the project repository's

## Additional information

See: [Using conditionals to control job execution](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution)

## Related issues

Resolves #11 
